### PR TITLE
Recalculate counters after dummy data creation

### DIFF
--- a/app/src/main/java/com/zihowl/thecalendar/TheCalendar.java
+++ b/app/src/main/java/com/zihowl/thecalendar/TheCalendar.java
@@ -33,6 +33,8 @@ public class TheCalendar extends Application {
         if (isFirstLaunch) {
             TheCalendarRepository repository = TheCalendarRepository.getInstance(new RealmDataSource());
             repository.initializeDummyData();
+            // Make sure subject counters are correctly calculated before marking the first launch as complete
+            repository.recalculateAllSubjectCounters();
             prefs.edit().putBoolean(KEY_FIRST_LAUNCH, false).apply();
         }
     }

--- a/app/src/main/java/com/zihowl/thecalendar/data/repository/TheCalendarRepository.java
+++ b/app/src/main/java/com/zihowl/thecalendar/data/repository/TheCalendarRepository.java
@@ -51,6 +51,9 @@ public class TheCalendarRepository {
         if (localDataSource.getAllNotes().isEmpty()) {
             createDummyNotes().forEach(this::addNote);
         }
+        // Once all dummy data is inserted, ensure the counters of each subject
+        // reflect the current amount of pending tasks and notes.
+        recalculateAllSubjectCounters();
     }
 
     // --- MÉTODOS GET CON SINCRONIZACIÓN ---
@@ -215,6 +218,29 @@ public class TheCalendarRepository {
     public void updateNote(Note note) { localDataSource.saveNote(note); }
     public void deleteTasks(List<Task> tasks) { localDataSource.deleteTasks(tasks); }
     public void deleteNotes(List<Note> notes) { localDataSource.deleteNotes(notes); }
+
+    /**
+     * Recalculates the counters for a single subject based on current tasks and notes.
+     */
+    public void recalculateSubjectCounters(Subject subject) {
+        int pendingTasks = (int) localDataSource.getAllTasks().stream()
+                .filter(t -> !t.isCompleted() && subject.getName().equals(t.getSubjectName()))
+                .count();
+        int noteCount = (int) localDataSource.getAllNotes().stream()
+                .filter(n -> subject.getName().equals(n.getSubjectName()))
+                .count();
+
+        localDataSource.updateSubjectCounters(subject.getId(), pendingTasks, noteCount);
+    }
+
+    /**
+     * Iterates all subjects and updates their counters.
+     */
+    public void recalculateAllSubjectCounters() {
+        for (Subject subject : localDataSource.getAllSubjects()) {
+            recalculateSubjectCounters(subject);
+        }
+    }
 
     // --- DATOS DUMMY (PARA LA PRIMERA EJECUCIÓN) ---
     private List<Subject> createDummySubjects() {


### PR DESCRIPTION
## Summary
- recalc subject counters when inserting dummy data
- expose new `recalculateSubjectCounters` and `recalculateAllSubjectCounters`
- ensure counters are computed before clearing first launch flag

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68818ca5dd2c83288075e5ecd294a48c