### PR TITLE
Implement counter sync after updates

### DIFF
--- a/app/src/main/java/com/zihowl/thecalendar/data/source/local/RealmDataSource.java
+++ b/app/src/main/java/com/zihowl/thecalendar/data/source/local/RealmDataSource.java
@@ -40,6 +40,16 @@ public class RealmDataSource {
         }
     }
 
+    /**
+     * Obtiene una materia por su nombre exacto.
+     */
+    public Subject getSubjectByName(String name) {
+        try (Realm realm = Realm.getDefaultInstance()) {
+            Subject subject = realm.where(Subject.class).equalTo("name", name).findFirst();
+            return subject != null ? realm.copyFromRealm(subject) : null;
+        }
+    }
+
     public void updateSubjectCounters(int subjectId, int taskCount, int noteCount) {
         try (Realm realm = Realm.getDefaultInstance()) {
             realm.executeTransaction(r -> {


### PR DESCRIPTION
## Summary
- add helper methods to look up tasks and notes by id
- recalc subject counters locally when tasks or notes change
- expose helper `recalculateSubjectCounters(String)`
- provide `getSubjectByName` in `RealmDataSource`

## Testing
- `sh ./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688194193690832884c3c4a187c9cb3c