### PR TITLE
Fix subject counters on startup and edit

### DIFF
--- a/app/src/main/java/com/zihowl/thecalendar/TheCalendar.java
+++ b/app/src/main/java/com/zihowl/thecalendar/TheCalendar.java
@@ -30,12 +30,14 @@ public class TheCalendar extends Application {
         SharedPreferences prefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
         boolean isFirstLaunch = prefs.getBoolean(KEY_FIRST_LAUNCH, true);
 
+        TheCalendarRepository repository = TheCalendarRepository.getInstance(new RealmDataSource());
+
         if (isFirstLaunch) {
-            TheCalendarRepository repository = TheCalendarRepository.getInstance(new RealmDataSource());
             repository.initializeDummyData();
-            // Make sure subject counters are correctly calculated before marking the first launch as complete
-            repository.recalculateAllSubjectCounters();
             prefs.edit().putBoolean(KEY_FIRST_LAUNCH, false).apply();
         }
+
+        // Always ensure counters reflect current tasks and notes
+        repository.recalculateAllSubjectCounters();
     }
 }

--- a/app/src/main/java/com/zihowl/thecalendar/data/repository/TheCalendarRepository.java
+++ b/app/src/main/java/com/zihowl/thecalendar/data/repository/TheCalendarRepository.java
@@ -237,12 +237,34 @@ public class TheCalendarRepository {
     }
 
     public void updateTask(Task task) {
+        String originalSubjectName = null;
+        Task existing = getTaskById(task.getId());
+        if (existing != null) {
+            originalSubjectName = existing.getSubjectName();
+        }
+
         localDataSource.saveTask(task);
+
+        if (originalSubjectName != null && !originalSubjectName.equals(task.getSubjectName())) {
+            recalculateSubjectCounters(originalSubjectName);
+        }
+
         recalculateSubjectCounters(task.getSubjectName());
     }
 
     public void updateNote(Note note) {
+        String originalSubjectName = null;
+        Note existing = getNoteById(note.getId());
+        if (existing != null) {
+            originalSubjectName = existing.getSubjectName();
+        }
+
         localDataSource.saveNote(note);
+
+        if (originalSubjectName != null && !originalSubjectName.equals(note.getSubjectName())) {
+            recalculateSubjectCounters(originalSubjectName);
+        }
+
         recalculateSubjectCounters(note.getSubjectName());
     }
 


### PR DESCRIPTION
## Summary
- recalculate counters for the old subject when tasks or notes change subject
- always recalculate counters when app starts

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68819873c77c83288c16668adfbf2da0