### PR TITLE
Implement profile image upload

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,9 @@ dependencies {
 
     implementation("io.realm:realm-android-library:10.19.0")
 
+    implementation("com.github.bumptech.glide:glide:4.16.0")
+    annotationProcessor("com.github.bumptech.glide:compiler:4.16.0")
+
     // Retrofit
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
         android:name=".TheCalendar"

--- a/app/src/main/java/com/zihowl/thecalendar/data/model/ImageUploadResponse.java
+++ b/app/src/main/java/com/zihowl/thecalendar/data/model/ImageUploadResponse.java
@@ -1,0 +1,14 @@
+package com.zihowl.thecalendar.data.model;
+
+public class ImageUploadResponse {
+    private String mensaje;
+    private String ruta;
+
+    public String getMensaje() {
+        return mensaje;
+    }
+
+    public String getRuta() {
+        return ruta;
+    }
+}

--- a/app/src/main/java/com/zihowl/thecalendar/data/repository/AuthRepository.java
+++ b/app/src/main/java/com/zihowl/thecalendar/data/repository/AuthRepository.java
@@ -5,9 +5,16 @@ import android.content.Context;
 import com.zihowl.thecalendar.data.model.auth.AuthToken;
 import com.zihowl.thecalendar.data.model.auth.LoginRequest;
 import com.zihowl.thecalendar.data.model.auth.RegisterRequest;
+import com.zihowl.thecalendar.data.model.ImageUploadResponse;
 import com.zihowl.thecalendar.data.session.SessionManager;
 import com.zihowl.thecalendar.data.source.remote.ApiService;
 import com.zihowl.thecalendar.data.source.remote.RetrofitClient;
+
+import java.io.File;
+
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.RequestBody;
 
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -57,6 +64,26 @@ public class AuthRepository {
 
     public void logout() {
         sessionManager.clear();
+    }
+
+    public void uploadProfileImage(File file, Callback<ImageUploadResponse> callback) {
+        RequestBody reqFile = RequestBody.create(MediaType.parse("image/jpeg"), file);
+        MultipartBody.Part body = MultipartBody.Part.createFormData("imagen", file.getName(), reqFile);
+        RequestBody nombre = RequestBody.create(MediaType.parse("text/plain"), file.getName());
+        apiService.uploadImage(body, nombre).enqueue(new Callback<ImageUploadResponse>() {
+            @Override
+            public void onResponse(Call<ImageUploadResponse> call, Response<ImageUploadResponse> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    sessionManager.setProfileImage(response.body().getRuta());
+                }
+                callback.onResponse(call, response);
+            }
+
+            @Override
+            public void onFailure(Call<ImageUploadResponse> call, Throwable t) {
+                callback.onFailure(call, t);
+            }
+        });
     }
 
     public SessionManager getSessionManager() {

--- a/app/src/main/java/com/zihowl/thecalendar/data/session/SessionManager.java
+++ b/app/src/main/java/com/zihowl/thecalendar/data/session/SessionManager.java
@@ -11,6 +11,7 @@ public class SessionManager {
     private static final String PREFS = "auth_prefs";
     private static final String KEY_TOKEN = "jwt_token";
     private static final String KEY_USER = "username";
+    private static final String KEY_PROFILE = "profile_path";
 
     private final SharedPreferences prefs;
 
@@ -33,6 +34,14 @@ public class SessionManager {
 
     public void saveSession(String username, String token) {
         prefs.edit().putString(KEY_USER, username).putString(KEY_TOKEN, token).apply();
+    }
+
+    public void setProfileImage(String path) {
+        prefs.edit().putString(KEY_PROFILE, path).apply();
+    }
+
+    public String getProfileImage() {
+        return prefs.getString(KEY_PROFILE, "");
     }
 
     public String getToken() {

--- a/app/src/main/java/com/zihowl/thecalendar/data/source/remote/ApiService.java
+++ b/app/src/main/java/com/zihowl/thecalendar/data/source/remote/ApiService.java
@@ -11,7 +11,9 @@ import com.zihowl.thecalendar.data.source.remote.graphql.NotesData;
 
 import retrofit2.Call;
 import retrofit2.http.Body;
+import retrofit2.http.Multipart;
 import retrofit2.http.POST;
+import retrofit2.http.Part;
 
 /**
  * Endpoints para autenticación REST y operaciones GraphQL.
@@ -38,4 +40,12 @@ public interface ApiService {
     // --- Mutaciones GraphQL ---
     @POST("graphql")
     Call<GraphQLResponse<Object>> mutate(@Body GraphQLRequest body);
+
+    // --- Subir imagen de perfil ---
+    @Multipart
+    @POST("api/subir-imagen")
+    Call<com.zihowl.thecalendar.data.model.ImageUploadResponse> uploadImage(
+            @Part okhttp3.MultipartBody.Part imagen,
+            @Part("nombre") okhttp3.RequestBody nombre
+    );
 }

--- a/app/src/main/java/com/zihowl/thecalendar/data/source/remote/RetrofitClient.java
+++ b/app/src/main/java/com/zihowl/thecalendar/data/source/remote/RetrofitClient.java
@@ -15,6 +15,10 @@ public class RetrofitClient {
     // Usamos una URL pública de prueba por ahora.
     private static final String BASE_URL = "http://192.168.137.100:5000";
 
+    public static String getBaseUrl() {
+        return BASE_URL;
+    }
+
     public static Retrofit getClient(SessionManager sessionManager) {
         if (retrofit == null) {
             // Interceptor para ver los logs de las llamadas a la API en el Logcat.

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -13,9 +13,9 @@
     android:theme="@style/ThemeOverlay.AppCompat.Dark">
 
     <ImageView
-        android:id="@+id/imageView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:id="@+id/header_profile_image"
+        android:layout_width="72dp"
+        android:layout_height="72dp"
         android:contentDescription="@string/nav_header_desc"
         android:paddingTop="@dimen/nav_header_vertical_spacing"
         app:srcCompat="@mipmap/ic_launcher_round" />


### PR DESCRIPTION
## Summary
- add Flask endpoint to handle profile image uploads
- create Java model and Retrofit endpoint for uploads
- store profile image path in SessionManager
- update MainActivity to select and upload images
- show profile image in nav drawer
- add Glide dependency for loading images
- grant storage permissions

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688315d94e60832893818270464cae51