### PR TITLE
Switch JWT expiry to local timezone

### DIFF
--- a/app.py
+++ b/app.py
@@ -643,8 +643,14 @@ def login_user():
     usuario = db.session.query(Usuario).filter_by(nombre_usuario=data.get('nombre_usuario')).first()
     if not usuario or not usuario.verificar_contrasena(data.get('contrasena')): return jsonify(
         {'message': 'Credenciales inválidas'}), 401
-    token = jwt.encode({'id': usuario.id, 'exp': datetime.now() + timedelta(hours=24)},
-                       app.config['SECRET_KEY'], algorithm="HS256")
+    token = jwt.encode(
+        {
+            'id': usuario.id,
+            'exp': datetime.now().astimezone() + timedelta(hours=24)
+        },
+        app.config['SECRET_KEY'],
+        algorithm="HS256"
+    )
     return jsonify({'token': token})
 
 


### PR DESCRIPTION
## Summary
- use `datetime.now().astimezone()` for JWT expiry to keep consistent local timezone

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68831d2c2ac48328b7d3d020d5b395c4