### PR TITLE
Add sync button and improve status

### DIFF
--- a/app/src/main/java/com/zihowl/thecalendar/data/repository/TheCalendarRepository.java
+++ b/app/src/main/java/com/zihowl/thecalendar/data/repository/TheCalendarRepository.java
@@ -680,6 +680,13 @@ public class TheCalendarRepository {
     }
 
     /**
+     * Returns true if there are local changes pending synchronization.
+     */
+    public boolean hasPendingOperations() {
+        return !localDataSource.getAllPendingOperations().isEmpty();
+    }
+
+    /**
      * Sincroniza con el servidor aplicando estrategia "last-write-wins".
      * Este es un ejemplo simple de subida y descarga de datos.
      */

--- a/app/src/main/java/com/zihowl/thecalendar/ui/main/MainActivity.java
+++ b/app/src/main/java/com/zihowl/thecalendar/ui/main/MainActivity.java
@@ -52,9 +52,11 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     private TextView headerUser;
     private TextView headerStatus;
     private android.widget.ImageView headerProfileImage;
+    private View syncButton;
     private static final int PICK_IMAGE_REQUEST = 1001;
     private AuthRepository authRepository;
     private SyncManager syncManager;
+    private TheCalendarRepository repository;
 
     private SubjectsViewModel subjectsViewModel;
     private TasksViewModel tasksViewModel;
@@ -74,12 +76,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
         authRepository = new AuthRepository(this);
         syncManager = SyncManager.getInstance(this);
+        repository = TheCalendarRepository.getInstance(new RealmDataSource(), authRepository.getSessionManager());
 
         NavigationView navigationView = findViewById(R.id.nav_view);
         View header = navigationView.getHeaderView(0);
         headerUser = header.findViewById(R.id.header_user);
         headerStatus = header.findViewById(R.id.header_sync_status);
         headerProfileImage = header.findViewById(R.id.header_profile_image);
+        syncButton = navigationView.findViewById(R.id.nav_sync_button);
         String photo = authRepository.getSessionManager().getProfileImage();
         if (!photo.isEmpty()) {
             com.bumptech.glide.Glide.with(this)
@@ -96,14 +100,22 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             name = getString(R.string.default_username);
         }
         headerUser.setText(name);
+        if (syncButton != null) {
+            syncButton.setOnClickListener(v -> syncManager.scheduleSync());
+        }
         syncManager.getStatus().observe(this, status -> {
-            String text = switch (status) {
-                case OFFLINE -> getString(R.string.sync_offline);
-                case CONNECTED -> getString(R.string.sync_connected);
-                case SYNCING -> getString(R.string.sync_syncing);
-                case COMPLETE -> getString(R.string.sync_complete);
-                case ERROR -> getString(R.string.sync_error);
-            };
+            String text;
+            if (status == SyncStatus.SYNCING) {
+                text = getString(R.string.sync_syncing);
+            } else if (status == SyncStatus.ERROR) {
+                text = getString(R.string.sync_error);
+            } else if (status == SyncStatus.OFFLINE) {
+                text = getString(R.string.sync_offline);
+            } else if (repository.hasPendingOperations()) {
+                text = getString(R.string.sync_pending);
+            } else {
+                text = getString(R.string.sync_complete);
+            }
             headerStatus.setText(text);
         });
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -24,6 +24,8 @@
         app:headerLayout="@layout/nav_header_main"
         app:menu="@menu/activity_main_drawer">
 
+        <include layout="@layout/nav_sync_button"/>
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/nav_sync_button.xml
+++ b/app/src/main/res/layout/nav_sync_button.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:layout_marginStart="10dp"
+    android:padding="6dp">
+
+    <TextView
+        android:id="@+id/nav_sync_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/action_sync"
+        android:gravity="center_vertical"
+        android:clickable="true"
+        android:focusable="true"
+        android:background="?attr/selectableItemBackground"
+        android:minHeight="48dp"
+        android:drawablePadding="32dp"
+        android:drawableStart="@android:drawable/stat_notify_sync"
+        android:textColor="?android:attr/textColorPrimary" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,8 @@
     <string name="sync_syncing">Sincronizando…</string>
     <string name="sync_complete">Sync completa</string>
     <string name="sync_error">Error de sync</string>
+    <string name="sync_pending">Cambios pendientes</string>
+    <string name="action_sync">Sincronizar</string>
     <string name="continue_without_account">Continuar sin cuenta</string>
     <string name="no_subjects">No hay materias registradas</string>
     <string name="no_tasks">No hay tareas registradas</string>


### PR DESCRIPTION
## Summary
- add a layout for a new Sync button
- show the sync button in the drawer
- show pending sync and Sync option strings
- expose repo method to check for pending operations
- show new sync status logic in `MainActivity`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68832cd7f8bc8328aa3a9630f1c6c970