### PR TITLE
Add profile photo persistence

### DIFF
--- a/app/src/main/java/com/zihowl/thecalendar/data/model/auth/AuthToken.java
+++ b/app/src/main/java/com/zihowl/thecalendar/data/model/auth/AuthToken.java
@@ -1,9 +1,17 @@
 package com.zihowl.thecalendar.data.model.auth;
 
+import com.google.gson.annotations.SerializedName;
+
 public class AuthToken {
     private String token;
+    @SerializedName("foto_perfil")
+    private String fotoPerfil;
 
     public String getToken() {
         return token;
+    }
+
+    public String getFotoPerfil() {
+        return fotoPerfil;
     }
 }

--- a/app/src/main/java/com/zihowl/thecalendar/data/repository/AuthRepository.java
+++ b/app/src/main/java/com/zihowl/thecalendar/data/repository/AuthRepository.java
@@ -35,6 +35,7 @@ public class AuthRepository {
             public void onResponse(Call<AuthToken> call, Response<AuthToken> response) {
                 if (response.isSuccessful() && response.body() != null) {
                     sessionManager.saveSession(username, response.body().getToken());
+                    sessionManager.setProfileImage(response.body().getFotoPerfil());
                     callback.onResponse(null, Response.success(true));
                 } else {
                     callback.onResponse(null, Response.success(false));


### PR DESCRIPTION
## Summary
- allow storing the profile photo path in users table
- secure the image upload endpoint and update the logged user
- return photo path on login
- expose photo path in Android model and save it on login

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68834a1f63808328bb757b92c8075a0e