### PR TITLE
Switch to local time

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,7 +95,7 @@ class Imagen(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     id_usuario = db.Column(db.Integer, db.ForeignKey('usuarios.id'), nullable=False, unique=True)
     ruta = db.Column(db.String(255), nullable=False)
-    fecha = db.Column(db.DateTime, default=datetime.utcnow)
+    fecha = db.Column(db.DateTime, default=datetime.now)
     usuario = db.relationship('Usuario', backref=db.backref('imagen', uselist=False))
 # --- 3. DECORADOR DE TOKEN Y UTILIDADES ---
 def token_required(f):

--- a/app/src/main/java/com/zihowl/thecalendar/ui/tasks/AddTaskDialogFragment.java
+++ b/app/src/main/java/com/zihowl/thecalendar/ui/tasks/AddTaskDialogFragment.java
@@ -26,7 +26,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 public class AddTaskDialogFragment extends DialogFragment {
@@ -134,13 +133,10 @@ public class AddTaskDialogFragment extends DialogFragment {
     private void showDatePicker() {
         MaterialDatePicker<Long> datePicker = MaterialDatePicker.Builder.datePicker()
                 .setTitleText("Seleccionar fecha")
-                .setSelection(selectedDate != null ? selectedDate.getTime() : MaterialDatePicker.todayInUtcMilliseconds())
+                .setSelection(selectedDate != null ? selectedDate.getTime() : System.currentTimeMillis())
                 .build();
         datePicker.addOnPositiveButtonClickListener(selection -> {
-            // Se debe ajustar la zona horaria para evitar problemas de un día antes/después
-            TimeZone tz = TimeZone.getDefault();
-            long offset = tz.getOffset(selection);
-            selectedDate = new Date(selection + offset);
+            selectedDate = new Date(selection);
             updateDateLabel();
         });
         datePicker.show(getParentFragmentManager(), "DatePicker");


### PR DESCRIPTION
## Summary
- use `datetime.now` for timestamps instead of `utcnow`
- set `AddTaskDialogFragment` date picker to use local time directly

## Testing
- `python3 -m py_compile app.py`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883592abeb88328a9e1b3bf8036863c