### PR TITLE
Allow creating tasks and notes without a subject

### DIFF
--- a/app.py
+++ b/app.py
@@ -427,22 +427,25 @@ class DesvincularYEliminarMateria(graphene.Mutation):
 class CrearTarea(graphene.Mutation):
     class Arguments:
         titulo = graphene.String(required=True)
-        id_materia = graphene.ID(required=True)
+        id_materia = graphene.ID()
         descripcion = graphene.String()
         fecha_entrega = graphene.DateTime()
 
     tarea = graphene.Field(lambda: TareaType)
 
     @token_required
-    def mutate(root, info, titulo, id_materia, **kwargs):
-        try:
-            type_name, real_id_materia = from_global_id(id_materia)
-            if type_name != 'MateriaType': raise Exception("ID de Materia inválido")
-        except:
-            real_id_materia = int(id_materia)
+    def mutate(root, info, titulo, id_materia=None, **kwargs):
+        real_id_materia = None
+        if id_materia:
+            try:
+                type_name, real_id_materia = from_global_id(id_materia)
+                if type_name != 'MateriaType':
+                    raise Exception("ID de Materia inválido")
+            except Exception:
+                real_id_materia = int(id_materia)
 
-        if not db.session.get(Materia, real_id_materia):
-            raise Exception("Materia no encontrada.")
+            if not db.session.get(Materia, real_id_materia):
+                raise Exception("Materia no encontrada.")
 
         tarea = Tarea(titulo=titulo, id_materia=real_id_materia, id_usuario=info.context.user.id, **kwargs)
         db.session.add(tarea)
@@ -504,21 +507,24 @@ class EliminarTarea(graphene.Mutation):
 class CrearNota(graphene.Mutation):
     class Arguments:
         titulo = graphene.String(required=True)
-        id_materia = graphene.ID(required=True)
+        id_materia = graphene.ID()
         contenido = graphene.String()
 
     nota = graphene.Field(lambda: NotaType)
 
     @token_required
-    def mutate(root, info, titulo, id_materia, **kwargs):
-        try:
-            type_name, real_id_materia = from_global_id(id_materia)
-            if type_name != 'MateriaType': raise Exception("ID de Materia inválido")
-        except:
-            real_id_materia = int(id_materia)
+    def mutate(root, info, titulo, id_materia=None, **kwargs):
+        real_id_materia = None
+        if id_materia:
+            try:
+                type_name, real_id_materia = from_global_id(id_materia)
+                if type_name != 'MateriaType':
+                    raise Exception("ID de Materia inválido")
+            except Exception:
+                real_id_materia = int(id_materia)
 
-        if not db.session.get(Materia, real_id_materia):
-            raise Exception("Materia no encontrada.")
+            if not db.session.get(Materia, real_id_materia):
+                raise Exception("Materia no encontrada.")
 
         nota = Nota(titulo=titulo, id_materia=real_id_materia, id_usuario=info.context.user.id, **kwargs)
         db.session.add(nota)

--- a/app/src/main/java/com/zihowl/thecalendar/data/repository/TheCalendarRepository.java
+++ b/app/src/main/java/com/zihowl/thecalendar/data/repository/TheCalendarRepository.java
@@ -352,7 +352,7 @@ public class TheCalendarRepository {
         localDataSource.saveTask(task); // Guardado local primero
         recalculateSubjectCounters(task.getSubjectName());
         long opId = queueOperation("task", "CREATE", task);
-        String q = "mutation($titulo:String!,$descripcion:String,$fecha:DateTime,$idMateria:ID!){ crearTarea(titulo:$titulo,idMateria:$idMateria,descripcion:$descripcion,fechaEntrega:$fecha){ tarea{ id: dbId } } }";
+        String q = "mutation($titulo:String!,$descripcion:String,$fecha:DateTime,$idMateria:ID){ crearTarea(titulo:$titulo,idMateria:$idMateria,descripcion:$descripcion,fechaEntrega:$fecha){ tarea{ id: dbId } } }";
         Map<String,Object> vars = new HashMap<>();
         vars.put("titulo", task.getTitle());
         vars.put("descripcion", task.getDescription());
@@ -404,7 +404,7 @@ public class TheCalendarRepository {
         localDataSource.saveNote(note); // Guardado local primero
         recalculateSubjectCounters(note.getSubjectName());
         long opId = queueOperation("note", "CREATE", note);
-        String qn = "mutation($titulo:String!,$contenido:String,$idMateria:ID!){ crearNota(titulo:$titulo,idMateria:$idMateria,contenido:$contenido){ nota{ id: dbId } } }";
+        String qn = "mutation($titulo:String!,$contenido:String,$idMateria:ID){ crearNota(titulo:$titulo,idMateria:$idMateria,contenido:$contenido){ nota{ id: dbId } } }";
         Map<String,Object> varsN = new HashMap<>();
         varsN.put("titulo", note.getTitle());
         varsN.put("contenido", note.getContent());
@@ -777,7 +777,7 @@ public class TheCalendarRepository {
                 case "task":
                     Task t = gson.fromJson(op.getPayload(), Task.class);
                     if ("CREATE".equals(op.getAction())) {
-                        String m="mutation($titulo:String!,$descripcion:String,$fecha:DateTime,$idMateria:ID!){ crearTarea(titulo:$titulo,idMateria:$idMateria,descripcion:$descripcion,fechaEntrega:$fecha){ tarea{ id: dbId } } }";
+                        String m="mutation($titulo:String!,$descripcion:String,$fecha:DateTime,$idMateria:ID){ crearTarea(titulo:$titulo,idMateria:$idMateria,descripcion:$descripcion,fechaEntrega:$fecha){ tarea{ id: dbId } } }";
                         Map<String,Object> v=new HashMap<>(); v.put("titulo",t.getTitle()); v.put("descripcion",t.getDescription()); v.put("fecha",t.getDueDate()); v.put("idMateria",t.getSubjectId());
                         api.mutate(new GraphQLRequest(m,v)).execute();
                     } else if ("UPDATE".equals(op.getAction())) {
@@ -792,7 +792,7 @@ public class TheCalendarRepository {
                 case "note":
                     Note n = gson.fromJson(op.getPayload(), Note.class);
                     if ("CREATE".equals(op.getAction())) {
-                        String m="mutation($titulo:String!,$contenido:String,$idMateria:ID!){ crearNota(titulo:$titulo,idMateria:$idMateria,contenido:$contenido){ nota{ id: dbId } } }";
+                        String m="mutation($titulo:String!,$contenido:String,$idMateria:ID){ crearNota(titulo:$titulo,idMateria:$idMateria,contenido:$contenido){ nota{ id: dbId } } }";
                         Map<String,Object> v=new HashMap<>(); v.put("titulo",n.getTitle()); v.put("contenido",n.getContent()); v.put("idMateria",n.getSubjectId());
                         api.mutate(new GraphQLRequest(m,v)).execute();
                     } else if ("UPDATE".equals(op.getAction())) {

--- a/app/src/main/java/com/zihowl/thecalendar/data/source/remote/RetrofitClient.java
+++ b/app/src/main/java/com/zihowl/thecalendar/data/source/remote/RetrofitClient.java
@@ -6,6 +6,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 public class RetrofitClient {
 
@@ -30,10 +32,14 @@ public class RetrofitClient {
                     .addInterceptor(logging)
                     .build();
 
+            Gson gson = new GsonBuilder()
+                    .setDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
+                    .create();
+
             retrofit = new Retrofit.Builder()
                     .baseUrl(BASE_URL)
                     .client(client)
-                    .addConverterFactory(GsonConverterFactory.create())
+                    .addConverterFactory(GsonConverterFactory.create(gson))
                     .build();
         }
         return retrofit;


### PR DESCRIPTION
## Summary
- allow optional subject ID in CrearTarea and CrearNota mutations
- use ISO date format for Retrofit client
- update client GraphQL mutations so `idMateria` is optional

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68836fe854dc8328bd43c1cda2a26b43