### PR TITLE
Fix subject updates for notes and tasks

### DIFF
--- a/app.py
+++ b/app.py
@@ -459,11 +459,12 @@ class ActualizarTarea(graphene.Mutation):
         titulo = graphene.String()
         descripcion = graphene.String()
         completada = graphene.Boolean()
+        id_materia = graphene.ID()
 
     tarea = graphene.Field(lambda: TareaType)
 
     @token_required
-    def mutate(root, info, id, **kwargs):
+    def mutate(root, info, id, id_materia=None, **kwargs):
         try:
             type_name, real_id = from_global_id(id)
             if type_name != 'TareaType': raise Exception("ID de Tarea inválido")
@@ -473,6 +474,20 @@ class ActualizarTarea(graphene.Mutation):
         tarea = db.session.get(Tarea, real_id)
         if not tarea or tarea.id_usuario != info.context.user.id:
             raise Exception("Tarea no encontrada.")
+
+        if id_materia is not None:
+            if id_materia == "":
+                tarea.id_materia = None
+            else:
+                try:
+                    type_name, real_id_materia = from_global_id(id_materia)
+                    if type_name != 'MateriaType':
+                        raise Exception("ID de Materia inválido")
+                except Exception:
+                    real_id_materia = int(id_materia)
+                if real_id_materia and not db.session.get(Materia, real_id_materia):
+                    raise Exception("Materia no encontrada.")
+                tarea.id_materia = real_id_materia
 
         for key, value in kwargs.items():
             setattr(tarea, key, value)
@@ -537,11 +552,12 @@ class ActualizarNota(graphene.Mutation):
         id = graphene.ID(required=True)
         titulo = graphene.String()
         contenido = graphene.String()
+        id_materia = graphene.ID()
 
     nota = graphene.Field(lambda: NotaType)
 
     @token_required
-    def mutate(root, info, id, **kwargs):
+    def mutate(root, info, id, id_materia=None, **kwargs):
         try:
             type_name, real_id = from_global_id(id)
             if type_name != 'NotaType': raise Exception("ID de Nota inválido")
@@ -552,8 +568,24 @@ class ActualizarNota(graphene.Mutation):
         if not nota or nota.id_usuario != info.context.user.id:
             raise Exception("Nota no encontrada.")
 
-        if 'titulo' in kwargs: nota.titulo = kwargs['titulo']
-        if 'contenido' in kwargs: nota.contenido = kwargs['contenido']
+        if id_materia is not None:
+            if id_materia == "":
+                nota.id_materia = None
+            else:
+                try:
+                    type_name, real_id_materia = from_global_id(id_materia)
+                    if type_name != 'MateriaType':
+                        raise Exception("ID de Materia inválido")
+                except Exception:
+                    real_id_materia = int(id_materia)
+                if real_id_materia and not db.session.get(Materia, real_id_materia):
+                    raise Exception("Materia no encontrada.")
+                nota.id_materia = real_id_materia
+
+        if 'titulo' in kwargs:
+            nota.titulo = kwargs['titulo']
+        if 'contenido' in kwargs:
+            nota.contenido = kwargs['contenido']
 
         db.session.commit()
         return ActualizarNota(nota=nota)

--- a/app/src/main/java/com/zihowl/thecalendar/data/repository/TheCalendarRepository.java
+++ b/app/src/main/java/com/zihowl/thecalendar/data/repository/TheCalendarRepository.java
@@ -543,12 +543,13 @@ public class TheCalendarRepository {
         }
         localDataSource.saveTask(task);
         long opId = queueOperation("task", "UPDATE", task);
-        String q = "mutation($id:ID!,$titulo:String,$descripcion:String,$completada:Boolean){ actualizarTarea(id:$id,titulo:$titulo,descripcion:$descripcion,completada:$completada){ tarea{ id: dbId } } }";
+        String q = "mutation($id:ID!,$titulo:String,$descripcion:String,$completada:Boolean,$idMateria:ID){ actualizarTarea(id:$id,titulo:$titulo,descripcion:$descripcion,completada:$completada,idMateria:$idMateria){ tarea{ id: dbId } } }";
         Map<String,Object> vars = new HashMap<>();
         vars.put("id", task.getId());
         vars.put("titulo", task.getTitle());
         vars.put("descripcion", task.getDescription());
         vars.put("completada", task.isCompleted());
+        vars.put("idMateria", task.getSubjectId());
         if (isLoggedIn()) {
             remoteDataSource.mutate(new GraphQLRequest(q, vars)).enqueue(new Callback<GraphQLResponse<Object>>() {
                 @Override
@@ -590,11 +591,12 @@ public class TheCalendarRepository {
         }
         localDataSource.saveNote(note);
         long opId = queueOperation("note", "UPDATE", note);
-        String q = "mutation($id:ID!,$titulo:String,$contenido:String){ actualizarNota(id:$id,titulo:$titulo,contenido:$contenido){ nota{ id: dbId } } }";
+        String q = "mutation($id:ID!,$titulo:String,$contenido:String,$idMateria:ID){ actualizarNota(id:$id,titulo:$titulo,contenido:$contenido,idMateria:$idMateria){ nota{ id: dbId } } }";
         Map<String,Object> vars = new HashMap<>();
         vars.put("id", note.getId());
         vars.put("titulo", note.getTitle());
         vars.put("contenido", note.getContent());
+        vars.put("idMateria", note.getSubjectId());
         if (isLoggedIn()) {
             remoteDataSource.mutate(new GraphQLRequest(q, vars)).enqueue(new Callback<GraphQLResponse<Object>>() {
                 @Override
@@ -783,8 +785,8 @@ public class TheCalendarRepository {
                         Map<String,Object> v=new HashMap<>(); v.put("titulo",t.getTitle()); v.put("descripcion",t.getDescription()); v.put("fecha",t.getDueDate()); if(t.getSubjectId()!=null){ v.put("idMateria",t.getSubjectId()); }
                         api.mutate(new GraphQLRequest(m,v)).execute();
                     } else if ("UPDATE".equals(op.getAction())) {
-                        String m="mutation($id:ID!,$titulo:String,$descripcion:String,$completada:Boolean){ actualizarTarea(id:$id,titulo:$titulo,descripcion:$descripcion,completada:$completada){ tarea{ id: dbId } } }";
-                        Map<String,Object> v=new HashMap<>(); v.put("id",t.getId()); v.put("titulo",t.getTitle()); v.put("descripcion",t.getDescription()); v.put("completada",t.isCompleted());
+                        String m="mutation($id:ID!,$titulo:String,$descripcion:String,$completada:Boolean,$idMateria:ID){ actualizarTarea(id:$id,titulo:$titulo,descripcion:$descripcion,completada:$completada,idMateria:$idMateria){ tarea{ id: dbId } } }";
+                        Map<String,Object> v=new HashMap<>(); v.put("id",t.getId()); v.put("titulo",t.getTitle()); v.put("descripcion",t.getDescription()); v.put("completada",t.isCompleted()); if(t.getSubjectId()!=null){ v.put("idMateria",t.getSubjectId()); } else { v.put("idMateria",null); }
                         api.mutate(new GraphQLRequest(m,v)).execute();
                     } else if ("DELETE".equals(op.getAction())) {
                         String m="mutation($id:ID!){ eliminarTarea(id:$id){ ok }}"; Map<String,Object> v=new HashMap<>(); v.put("id",t.getId());
@@ -798,8 +800,8 @@ public class TheCalendarRepository {
                         Map<String,Object> v=new HashMap<>(); v.put("titulo",n.getTitle()); v.put("contenido",n.getContent()); if(n.getSubjectId()!=null){ v.put("idMateria",n.getSubjectId()); }
                         api.mutate(new GraphQLRequest(m,v)).execute();
                     } else if ("UPDATE".equals(op.getAction())) {
-                        String m="mutation($id:ID!,$titulo:String,$contenido:String){ actualizarNota(id:$id,titulo:$titulo,contenido:$contenido){ nota{ id: dbId } } }";
-                        Map<String,Object> v=new HashMap<>(); v.put("id",n.getId()); v.put("titulo",n.getTitle()); v.put("contenido",n.getContent());
+                        String m="mutation($id:ID!,$titulo:String,$contenido:String,$idMateria:ID){ actualizarNota(id:$id,titulo:$titulo,contenido:$contenido,idMateria:$idMateria){ nota{ id: dbId } } }";
+                        Map<String,Object> v=new HashMap<>(); v.put("id",n.getId()); v.put("titulo",n.getTitle()); v.put("contenido",n.getContent()); if(n.getSubjectId()!=null){ v.put("idMateria",n.getSubjectId()); } else { v.put("idMateria",null); }
                         api.mutate(new GraphQLRequest(m,v)).execute();
                     } else if ("DELETE".equals(op.getAction())) {
                         String m="mutation($id:ID!){ eliminarNota(id:$id){ ok }}"; Map<String,Object> v=new HashMap<>(); v.put("id",n.getId());


### PR DESCRIPTION
## Summary
- allow GraphQL mutations to modify `id_materia`
- update repository to pass subject id when editing notes or tasks

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68837bfd14cc83288aa6e08fa2453e8c