### PR TITLE
Implement local and FCM notifications

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     id("realm-android")
+    id("com.google.gms.google-services")
 }
 
 android {
@@ -50,6 +51,11 @@ dependencies {
 
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.viewpager2:viewpager2:1.1.0")
+
+    implementation("androidx.core:core:1.12.0")
+
+    // Firebase Cloud Messaging
+    implementation("com.google.firebase:firebase-messaging:23.4.0")
 
     implementation("io.realm:realm-android-library:10.19.0")
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,18 @@
                 <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />
             </intent-filter>
         </receiver>
+
+        <receiver
+            android:name="com.zihowl.thecalendar.notifications.ClassAlarmReceiver"
+            android:exported="false" />
+
+        <service
+            android:name="com.zihowl.thecalendar.notifications.MyFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/zihowl/thecalendar/TheCalendar.java
+++ b/app/src/main/java/com/zihowl/thecalendar/TheCalendar.java
@@ -4,6 +4,8 @@ import android.app.Application;
 import com.zihowl.thecalendar.data.repository.TheCalendarRepository;
 import com.zihowl.thecalendar.data.session.SessionManager;
 import com.zihowl.thecalendar.data.source.local.RealmDataSource;
+import com.zihowl.thecalendar.notifications.NotificationHelper;
+import com.zihowl.thecalendar.notifications.ClassNotificationScheduler;
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
 
@@ -29,5 +31,8 @@ public class TheCalendar extends Application {
 
         // Always ensure counters reflect current tasks and notes
         repository.recalculateAllSubjectCounters();
+
+        NotificationHelper.createNotificationChannel(this);
+        ClassNotificationScheduler.scheduleNextClass(this);
     }
 }

--- a/app/src/main/java/com/zihowl/thecalendar/notifications/ClassAlarmReceiver.java
+++ b/app/src/main/java/com/zihowl/thecalendar/notifications/ClassAlarmReceiver.java
@@ -1,0 +1,23 @@
+package com.zihowl.thecalendar.notifications;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+import com.zihowl.thecalendar.R;
+
+public class ClassAlarmReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String subject = intent.getStringExtra("subjectName");
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, NotificationHelper.CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_launcher_foreground)
+                .setContentTitle("Próxima clase")
+                .setContentText("En 5 minutos comienza " + subject)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setAutoCancel(true);
+        NotificationManagerCompat.from(context).notify(1001, builder.build());
+        ClassNotificationScheduler.scheduleNextClass(context);
+    }
+}

--- a/app/src/main/java/com/zihowl/thecalendar/notifications/ClassNotificationScheduler.java
+++ b/app/src/main/java/com/zihowl/thecalendar/notifications/ClassNotificationScheduler.java
@@ -1,0 +1,95 @@
+package com.zihowl.thecalendar.notifications;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+
+import com.zihowl.thecalendar.data.model.Subject;
+import com.zihowl.thecalendar.data.repository.TheCalendarRepository;
+import com.zihowl.thecalendar.data.session.SessionManager;
+import com.zihowl.thecalendar.data.source.local.RealmDataSource;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class ClassNotificationScheduler {
+
+    private static final Map<String, Integer> DAYS = new HashMap<>();
+    static {
+        DAYS.put("Lunes", Calendar.MONDAY);
+        DAYS.put("Martes", Calendar.TUESDAY);
+        DAYS.put("Miércoles", Calendar.WEDNESDAY);
+        DAYS.put("Miercoles", Calendar.WEDNESDAY);
+        DAYS.put("Jueves", Calendar.THURSDAY);
+        DAYS.put("Viernes", Calendar.FRIDAY);
+        DAYS.put("Sábado", Calendar.SATURDAY);
+        DAYS.put("Sabado", Calendar.SATURDAY);
+        DAYS.put("Domingo", Calendar.SUNDAY);
+    }
+
+    public static void scheduleNextClass(Context context) {
+        TheCalendarRepository repo = TheCalendarRepository.getInstance(new RealmDataSource(), new SessionManager(context));
+        List<Subject> subjects = repo.getSubjects();
+        if (subjects == null || subjects.isEmpty()) return;
+
+        SimpleDateFormat sdf = new SimpleDateFormat("HH:mm", Locale.getDefault());
+        Calendar now = Calendar.getInstance();
+        long nowMillis = now.getTimeInMillis();
+        long bestTime = Long.MAX_VALUE;
+        String bestSubject = null;
+
+        for (Subject s : subjects) {
+            String schedule = s.getSchedule();
+            if (schedule == null) continue;
+            for (String line : schedule.split("\n")) {
+                line = line.trim();
+                if (line.isEmpty()) continue;
+                String[] parts = line.split(" ", 2);
+                if (parts.length < 2) continue;
+                Integer day = DAYS.get(parts[0]);
+                if (day == null) continue;
+                String[] times = parts[1].trim().split(" - ");
+                if (times.length != 2) continue;
+                try {
+                    Date start = sdf.parse(times[0]);
+                    Calendar cal = Calendar.getInstance();
+                    cal.set(Calendar.DAY_OF_WEEK, day);
+                    cal.set(Calendar.HOUR_OF_DAY, start.getHours());
+                    cal.set(Calendar.MINUTE, start.getMinutes());
+                    cal.set(Calendar.SECOND, 0);
+                    cal.set(Calendar.MILLISECOND, 0);
+                    if (cal.getTimeInMillis() <= nowMillis) {
+                        cal.add(Calendar.WEEK_OF_YEAR, 1);
+                    }
+                    long trigger = cal.getTimeInMillis() - 5 * 60 * 1000;
+                    if (trigger > nowMillis && trigger < bestTime) {
+                        bestTime = trigger;
+                        bestSubject = s.getName();
+                    }
+                } catch (ParseException ignored) { }
+            }
+        }
+
+        if (bestSubject != null) {
+            AlarmManager am = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+            Intent i = new Intent(context, ClassAlarmReceiver.class);
+            i.putExtra("subjectName", bestSubject);
+            PendingIntent pi = PendingIntent.getBroadcast(context, 1001, i, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+            if (am != null) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    am.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, bestTime, pi);
+                } else {
+                    am.setExact(AlarmManager.RTC_WAKEUP, bestTime, pi);
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/zihowl/thecalendar/notifications/MyFirebaseMessagingService.java
+++ b/app/src/main/java/com/zihowl/thecalendar/notifications/MyFirebaseMessagingService.java
@@ -1,0 +1,27 @@
+package com.zihowl.thecalendar.notifications;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+import com.google.firebase.messaging.FirebaseMessagingService;
+import com.google.firebase.messaging.RemoteMessage;
+import com.zihowl.thecalendar.R;
+
+public class MyFirebaseMessagingService extends FirebaseMessagingService {
+    @Override
+    public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
+        if (remoteMessage.getNotification() != null) {
+            String title = remoteMessage.getNotification().getTitle();
+            String body = remoteMessage.getNotification().getBody();
+
+            NotificationCompat.Builder builder = new NotificationCompat.Builder(this, NotificationHelper.CHANNEL_ID)
+                    .setSmallIcon(R.drawable.ic_launcher_foreground)
+                    .setContentTitle(title)
+                    .setContentText(body)
+                    .setPriority(NotificationCompat.PRIORITY_HIGH)
+                    .setAutoCancel(true);
+
+            NotificationManagerCompat.from(this).notify(2002, builder.build());
+        }
+    }
+}

--- a/app/src/main/java/com/zihowl/thecalendar/notifications/NotificationHelper.java
+++ b/app/src/main/java/com/zihowl/thecalendar/notifications/NotificationHelper.java
@@ -1,0 +1,25 @@
+package com.zihowl.thecalendar.notifications;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.os.Build;
+
+public class NotificationHelper {
+    public static final String CHANNEL_ID = "class_channel";
+
+    public static void createNotificationChannel(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(
+                    CHANNEL_ID,
+                    "Recordatorios de clases",
+                    NotificationManager.IMPORTANCE_DEFAULT
+            );
+            channel.setDescription("Notifica 5 minutos antes de cada clase");
+            NotificationManager manager = context.getSystemService(NotificationManager.class);
+            if (manager != null) {
+                manager.createNotificationChannel(channel);
+            }
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,5 +10,6 @@ buildscript {
     }
     dependencies {
         classpath("io.realm:realm-gradle-plugin:10.19.0")
+        classpath("com.google.gms:google-services:4.3.15")
     }
 }


### PR DESCRIPTION
## Summary
- add google-services classpath
- enable google-services plugin for app
- add dependencies for core and Firebase Messaging
- create NotificationHelper with channel
- schedule alarms for next class and show notifications
- support remote FCM messages
- register receiver and service in manifest

## Testing
- `./gradlew -q tasks` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68839b1656bc83288b445a5fc95978b5