### PR TITLE
Add placeholder google-services.json to allow build

### DIFF
--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,28 @@
+{
+  "project_info": {
+    "project_number": "1234567890",
+    "project_id": "placeholder-project"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:1234567890:android:abcdef0123456789",
+        "android_client_info": {
+          "package_name": "com.zihowl.thecalendar"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "PLACEHOLDER_KEY"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
## Summary
- add a sample `google-services.json` so that the project can run the Gradle tasks

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883a2243e648328ae99cf18930bc410