### PR TITLE
Improve network security

### DIFF
--- a/app.py
+++ b/app.py
@@ -791,4 +791,11 @@ if __name__ == '__main__':
     with app.app_context():
         db.create_all()
         apply_migrations()
-    app.run(host='0.0.0.0', port=5000, debug=True)
+
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() == 'true'
+    port = int(os.getenv('PORT', '5000'))
+    cert = os.getenv('SSL_CERT')
+    key = os.getenv('SSL_KEY')
+    ssl_context = (cert, key) if cert and key else None
+
+    app.run(host='0.0.0.0', port=port, debug=debug_mode, ssl_context=ssl_context)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,6 +15,11 @@ android {
         versionCode = 1
         versionName = "1.0"
 
+        // Base URL para las peticiones. Puede ser establecido mediante la
+        // variable de entorno API_BASE_URL al momento de la compilación.
+        val apiUrl = System.getenv("API_BASE_URL") ?: "https://192.168.0.96:5000"
+        buildConfigField("String", "API_BASE_URL", "\"$apiUrl\"")
+
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -33,6 +38,7 @@ android {
     }
     buildFeatures {
         viewBinding = false
+        buildConfig = true
     }
 }
 

--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">192.168.0.96</domain>
+    </domain-config>
+</network-security-config>

--- a/app/src/main/java/com/zihowl/thecalendar/data/source/remote/RetrofitClient.java
+++ b/app/src/main/java/com/zihowl/thecalendar/data/source/remote/RetrofitClient.java
@@ -1,5 +1,6 @@
 package com.zihowl.thecalendar.data.source.remote;
 
+import com.zihowl.thecalendar.BuildConfig;
 import com.zihowl.thecalendar.data.session.SessionManager;
 
 import okhttp3.OkHttpClient;
@@ -15,7 +16,7 @@ public class RetrofitClient {
     
     // URL base para las peticiones. Cuando tengas tu backend, la cambiarás.
     // Usamos una URL pública de prueba por ahora.
-    private static final String BASE_URL = "http://192.168.0.96:5000";
+    private static final String BASE_URL = BuildConfig.API_BASE_URL;
 
     public static String getBaseUrl() {
         return BASE_URL;

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">192.168.0.96</domain>
-    </domain-config>
+    <base-config cleartextTrafficPermitted="false" />
 </network-security-config>


### PR DESCRIPTION
## Summary
- load API base URL from environment during build
- enable BuildConfig generation
- use BuildConfig API_BASE_URL in `RetrofitClient`
- disable cleartext traffic for release and allow it only in debug
- allow HTTPS configuration when running the backend

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883a656d1b88328b54aa024201fe093