### PR TITLE
Configure custom certificate

### DIFF
--- a/app/src/main/res/raw/server_cert.pem
+++ b/app/src/main/res/raw/server_cert.pem
@@ -1,0 +1,5 @@
+# Replace this placeholder with the actual certificate of your backend server.
+# Example self-signed certificate begins with -----BEGIN CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtestcertificateplaceholder
+-----END CERTIFICATE-----

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <base-config cleartextTrafficPermitted="false" />
+    <!-- Trust the custom certificate used by the local server -->
+    <domain-config>
+        <domain includeSubdomains="true">192.168.137.100</domain>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="@raw/server_cert" />
+        </trust-anchors>
+    </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Summary
- add custom certificate placeholder in `res/raw`
- configure `network_security_config.xml` to trust the certificate for the local server

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b3158ccc8328aa3aee388f0c5628